### PR TITLE
Fixed index 10 typo in EventType

### DIFF
--- a/zerto/constants.py
+++ b/zerto/constants.py
@@ -101,7 +101,7 @@ event_type = ZertoConstantDict([
     (7, 'ProtectVM'),
     (8, 'UnprotectVM'),
     (9, 'InstallVra'),
-    (0, 'UninstallVra'),
+    (10, 'UninstallVra'),
     (11, 'UpdateProtectionGroup'),
     (12, 'InsertTaggedCP'),
     (13, 'HandleMirrorPromotion'),


### PR DESCRIPTION
The EventType list has a duplicate index 0 item instead of #10

`Traceback (most recent call last):
  File "./pull_event_info.py", line 46, in <module>
    main()
  File "./pull_event_info.py", line 42, in main
    for i in zapi.get_event():
  File "/usr/lib/python2.7/site-packages/zerto/__init__.py", line 228, in get_event
    return list([Event(**res) for res in req.json()])
  File "/usr/lib/python2.7/site-packages/zerto/event.py", line 18, in __init__
    self.event_type = event_type[kwargs['EventType']]
KeyError: 10
`