### PR TITLE
python  2.6 compatible

### DIFF
--- a/zerto/zertoobject.py
+++ b/zerto/zertoobject.py
@@ -8,7 +8,7 @@ class ZertoObject(object):
         return str(getattr(self, 'values', None))
 
     def __repr__(self):
-        return '<{} {}>'.format(
+        return '<{0} {1}>'.format(
             self.__class__.__name__, getattr(self, 'values', None))
 
 


### PR DESCRIPTION
    print obj.get_peersite()
  File "/usr/lib/python2.6/site-packages/zerto/zertoobject.py", line 12, in __repr__
    self.__class__.__name__, getattr(self, 'values', None))
ValueError: zero length field name in format